### PR TITLE
Update cloudflare_ddns

### DIFF
--- a/cloudflare_ddns
+++ b/cloudflare_ddns
@@ -10,7 +10,7 @@ fi
 
 # script settings
 LOGFILE=$(basename $0).log
-THROTTLE_SECONDS=0  # terminate prematurely if run too often
+THROTTLE_SECONDS=300  # terminate prematurely if run too often
 
 # user input IP address
 NEW_IP=$1

--- a/cloudflare_ddns
+++ b/cloudflare_ddns
@@ -10,7 +10,7 @@ fi
 
 # script settings
 LOGFILE=$(basename $0).log
-THROTTLE_SECONDS=300  # terminate prematurely if run too often
+THROTTLE_SECONDS=0  # terminate prematurely if run too often
 
 # user input IP address
 NEW_IP=$1
@@ -23,9 +23,15 @@ log_output()
 
 list_dns_records()
 {
-	OUTPUT=$(curl -s -X GET "https://api.cloudflare.com/client/v4/zones/$DNS_ZONE_ID/dns_records" \
-		-H "X-Auth-Email: $CLOUDFLARE_EMAIL" \
-		-H "X-Auth-Key: $CLOUDFLARE_API_KEY")
+	if [ -z "$CLOUDFLARE_API_TOKEN" ]
+	then
+                OUTPUT=$(curl -s -X GET "https://api.cloudflare.com/client/v4/zones/$DNS_ZONE_ID/dns_records" \
+                -H "X-Auth-Email: $CLOUDFLARE_EMAIL" \
+                -H "X-Auth-Key: $CLOUDFLARE_API_KEY")
+	else
+		OUTPUT=$(curl -s -X GET "https://api.cloudflare.com/client/v4/zones/$DNS_ZONE_ID/dns_records" \
+                -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN")
+	fi
 }
 
 list_dns_records_onsuccess()
@@ -45,11 +51,19 @@ list_dns_records_onthrottled()
 
 update_record()
 {
-	OUTPUT=$(curl -s -X PUT "https://api.cloudflare.com/client/v4/zones/$DNS_ZONE_ID/dns_records/$DNS_RECORD_ID" \
-		-H "X-Auth-Email: $CLOUDFLARE_EMAIL" \
-		-H "X-Auth-Key: $CLOUDFLARE_API_KEY" \
+	if [ -z "$CLOUDFLARE_API_TOKEN" ]
+	then
+	        OUTPUT=$(curl -s -X PUT "https://api.cloudflare.com/client/v4/zones/$DNS_ZONE_ID/dns_records/$DNS_RECORD_ID" \
+                -H "X-Auth-Email: $CLOUDFLARE_EMAIL" \
+                -H "X-Auth-Key: $CLOUDFLARE_API_KEY" \
+                -H "Content-Type: application/json" \
+                --data "{\"type\":\"$DNS_RECORD_TYPE\",\"name\":\"$DNS_RECORD_NAME\",\"content\":\"$NEW_IP\",\"proxied\":$PROXY_STATE}")
+	else
+	        OUTPUT=$(curl -s -X PUT "https://api.cloudflare.com/client/v4/zones/$DNS_ZONE_ID/dns_records/$DNS_RECORD_ID" \
+                -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
 		-H "Content-Type: application/json" \
-		--data "{\"type\":\"$DNS_RECORD_TYPE\",\"name\":\"$DNS_RECORD_NAME\",\"content\":\"$NEW_IP\"}")
+                --data "{\"type\":\"$DNS_RECORD_TYPE\",\"name\":\"$DNS_RECORD_NAME\",\"content\":\"$NEW_IP\",\"proxied\":$PROXY_STATE}")
+	fi
 }
 
 update_record_onsuccess()


### PR DESCRIPTION
This adds in support for the following:
- Use of Cloudflare new API Token instead of having to use the Global Key.  For more info on the difference see:
https://blog.cloudflare.com/api-tokens-general-availability/

- Addition of option to set record as a proxied record or not.

Usage:
See the .cloudflare_ddns configuration for changes