### PR TITLE
Support for Cloudflare TOKEN and proxy status

### DIFF
--- a/.cloudflare.example
+++ b/.cloudflare.example
@@ -15,6 +15,8 @@
 # account credentials
 CLOUDFLARE_EMAIL='<your cloudflare account email>'
 CLOUDFLARE_API_KEY='<your cloudflare account api key>'
+CLOUDFLARE_API_TOKEN='<if populated with a TOKEN will be used instead of above.  Keep empty if using standard KEY method.'
+
 
 # zone information
 DNS_ZONE_ID='<the id for the zone that contains your target dns record>'
@@ -23,4 +25,5 @@ DNS_ZONE_ID='<the id for the zone that contains your target dns record>'
 DNS_RECORD_ID='<the id for the target dns record>'
 DNS_RECORD_NAME='<the domain name to be changed>'
 DNS_RECORD_TYPE='A'
+PROXY_STATE='<false|true>'
 


### PR DESCRIPTION
This is to be used in conjunction with the updated script.
It adds:
- CLOUDFLARE_API_TOKEN configurable variable. If this is set it will take precedence over the EMAIL and API_KEY (they don't need to be populated).
- PROXY_STATE configurable variable which takes 'true' or 'false'.  The default previously was 'false' since this is what the API defaults to.  This allows setting to 'true' so record can be proxied (orange cloud).