### PR TITLE
Curl header formatting and last_run_time logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Features include:
 - [@clayauld](https://github.com/clayauld) - Verified works on RT-AC87U
 - [@ilasoft](https://github.com/ilasoft) - Verified works on RT-AX86U
 - [@sujitph](https://github.com/sujitph) - Verified works on GT-AX11000
+- [@scenix007](https://github.com/github007) - Upgrade for firmware 386.3, verified works on RT-AX86U
 
 ## How to Configure
 

--- a/cloudflare_ddns
+++ b/cloudflare_ddns
@@ -53,7 +53,7 @@ update_record()
 {
 	curl -s -X PUT "https://api.cloudflare.com/client/v4/zones/$DNS_ZONE_ID/dns_records/$DNS_RECORD_ID" \
 		--data "{\"type\":\"$DNS_RECORD_TYPE\",\"name\":\"$DNS_RECORD_NAME\",\"content\":\"$NEW_IP\",\"ttl\":1,\"proxied\":$DNS_RECORD_PROXIED}" \
-		-H "$CLOUDFLARE_AUTH_HEADERS"
+		-H "$CLOUDFLARE_AUTH_HEADERS" \
 		-H "Content-Type: application/json"
 		
 }


### PR DESCRIPTION
### Curl header formatting and last_run_time logic
-  Adjust curl header format to use -H option, the original ways reported syntax error on RT-AX86U running Merlin 386.3 with curl 7.76.1.
-  Rewrite last_run_time logic, using awk and date. The original way not working either.

### Tested Env
RT-AX86U , Asuswrt-Merlin version: 386.3
Curl info:
```bash
# curl -V
curl 7.76.1 (arm-buildroot-linux-gnueabi) libcurl/7.76.1 OpenSSL/1.1.1k
Release-Date: 2021-04-14
Protocols: file ftp ftps http https imap imaps mqtt pop3 pop3s smb smbs smtp smtps
Features: alt-svc IPv6 Largefile NTLM SSL TLS-SRP UnixSockets
```